### PR TITLE
FIX: Use relative form action to avoid hardcoded port

### DIFF
--- a/nginx/index.html
+++ b/nginx/index.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <h1>To-do List 입력</h1>
-    <form action="/add" method="post">
+    <form action="http://192.168.95.30:5000/add" method="post">
         <label>날짜: <input type="date" name="date"></label><br><br>
         <label>해야 하는 일: <input type="text" name="task"></label><br><br>
         <label>만나는 사람: <input type="text" name="person"></label><br><br>


### PR DESCRIPTION
This PR fixes the issue where the form action in `index.html` was hardcoded to a specific port.  
By using a relative path (`/add`), the application works correctly regardless of the deployment environment.
Related issue: #1